### PR TITLE
Fix Missing and Incorrect Kanji

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Genki 2: https://ankiweb.net/shared/info/969261095
 - "sound_file": (string) sound file used for this deck (starts searching in sound/ directory)
 - "skip_on_beginning": (integer) how many words should be skiped at the beginning of the sound file
 - "skip_with_new_category": (boolean) if true skips a word if new category starts
-- "skip_on_semikolon": (boolean) if true skips as many words as there are semikolons in the english translation, after a note
+- "skip_on_semicolon": (boolean) if true skips as many words as there are semicolons in the english translation, after a note
 - "uid": (integer) uniqe id, used for anki (should not be too high)
 - "sound_silence_threshold": (integer) magic number used for splitting genki-audiofiles into many seperate words. (default: 600)
 - "cards": list of categories

--- a/data/genki_1/templates/L00/01_greetings.yaml
+++ b/data/genki_1/templates/L00/01_greetings.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L00/K00_01.mp3
 skip_words: []
 skip_on_beginning: 0
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693903900
 sound_silence_threshold: 600
 cards:
@@ -38,7 +38,7 @@ cards:
   - japanese: いいえ。
     english: No.; Not at all.
     kanji: ''
-    skip_on_semikolon: false
+    skip_on_semicolon: false
   - japanese: いってきます。
     english: I'll go and come back.
     kanji: ''

--- a/data/genki_1/templates/L00/02_numbers_0-100.yaml
+++ b/data/genki_1/templates/L00/02_numbers_0-100.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L00/K00_02.mp3
 skip_words: []
 skip_on_beginning: 0
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693903901
 sound_silence_threshold: 400
 cards:

--- a/data/genki_1/templates/L01/01_vocabulary.yaml
+++ b/data/genki_1/templates/L01/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L01/K01_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: false
+skip_on_semicolon: false
 uid: 693904000
 sound_silence_threshold: 1000
 cards:
@@ -113,7 +113,7 @@ cards:
     english: um ...
     kanji: ''
   - japanese: はい
-    english: yes
+    english: yes (formal)
     kanji: ''
   - japanese: そうです
     english: That's right.

--- a/data/genki_1/templates/L01/02_additional_vocabulary.yaml
+++ b/data/genki_1/templates/L01/02_additional_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L01/K01_07.mp3
 skip_words: []
 skip_on_beginning: 1
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904001
 sound_silence_threshold: 600
 cards:

--- a/data/genki_1/templates/L01/04_years_old.yaml
+++ b/data/genki_1/templates/L01/04_years_old.yaml
@@ -36,7 +36,7 @@ cards:
   - japanese: じゅういっさい
     english: eleven years old
     kanji: 十一才
-  - japanese: はたち*
+  - japanese: はたち*／にじゅっさい
     english: 20 years old
     kanji: 二十才
   - japanese: にじゅういっさい

--- a/data/genki_1/templates/L02/01_vocabulary.yaml
+++ b/data/genki_1/templates/L02/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L02/K02_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904100
 sound_silence_threshold: 600
 cards:

--- a/data/genki_1/templates/L02/02_numbers_100-90000.yaml
+++ b/data/genki_1/templates/L02/02_numbers_100-90000.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L02/K02_07.mp3
 skip_words: []
 skip_on_beginning: 3
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904101
 sound_silence_threshold: 400
 cards:

--- a/data/genki_1/templates/L02/03_useful_expressions.yaml
+++ b/data/genki_1/templates/L02/03_useful_expressions.yaml
@@ -5,44 +5,44 @@ cards:
   vocabulary:
   - japanese: ほん
     english: book
-    kanjis: 本
+    kanji: 本
   - japanese: こくばん
     english: blackboard
-    kanjis: 黒板
+    kanji: 黒板
   - japanese: つくえ
     english: desk
-    kanjis: 机
+    kanji: 机
   - japanese: けしゴム
     english: eraser
-    kanjis: 消しゴム
+    kanji: 消しゴム
   - japanese: じしょ
     english: dictionary
-    kanjis: 辞書
+    kanji: 辞書
   - japanese: えんぴつ
     english: pencil
-    kanjis: 鉛筆
+    kanji: 鉛筆
   - japanese: でんき
     english: electricity; light
-    kanjis: 電気
+    kanji: 電気
   - japanese: ドア
     english: door
   - japanese: カーテン
     english: curtain
   - japanese: まど
     english: window
-    kanjis: 窓
+    kanji: 窓
   - japanese: いす
     english: chair
-    kanjis: 椅子
+    kanji: 椅子
   - japanese: わかりましたか。
     english: Do you understand?
-    kanjis: 分かりましたか。
+    kanji: 分かりましたか。
   - japanese: わかりました。
     english: I do understand./I understood.
-    kanjis: 分かりました。
+    kanji: 分かりました。
   - japanese: わかりません。
     english: I don't understand./I don't know.
-    kanjis: 分かりません。
+    kanji: 分かりません。
   - japanese: ゆっくり　いってください。
     english: Please say it slowly.
   - japanese: もういちど　いってください。

--- a/data/genki_1/templates/L03/01_vocabulary.yaml
+++ b/data/genki_1/templates/L03/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L03/K03_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904200
 sound_silence_threshold: 600
 cards:
@@ -120,7 +120,7 @@ cards:
   - japanese: きく
     english: to listen; to hear (〜を); to ask (<i>person</i>&nbsp;に)
     kanji: 聞く
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: のむ
     english: to drink (〜を)
     kanji: 飲む
@@ -195,5 +195,5 @@ cards:
     english: How about ...?; How is ...?
     kanji: ''
   - japanese: ええ
-    english: yes
+    english: yes (casual)
     kanji: ''

--- a/data/genki_1/templates/L04/01_vocabulary.yaml
+++ b/data/genki_1/templates/L04/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L04/K04_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904300
 sound_silence_threshold: 300
 cards:

--- a/data/genki_1/templates/L04/03_days_month.yaml
+++ b/data/genki_1/templates/L04/03_days_month.yaml
@@ -4,56 +4,56 @@ cards:
 - category: Useful_Expressions
   vocabulary:
   - japanese: ついたち*
-    english: day 1
+    english: first day of the month
     kanji: 一日
   - japanese: ふつか*
-    english: day 2
+    english: second day of the month
     kanji: 二日
   - japanese: みっか*
-    english: day 3
+    english: third day of the month
     kanji: 三日
   - japanese: よっか*
-    english: day 4
+    english: fourth day of the month 
     kanji: 四日
   - japanese: いつか*
-    english: day 5
+    english: fifth day of the month
     kanji: 五日
   - japanese: むいか*
-    english: day 6
+    english: sixth day of the month
     kanji: 六日
   - japanese: なのか*
-    english: day 7
+    english: seventh day of the month
     kanji: 七日
   - japanese: ようか*
-    english: day 8
+    english: eighth day of the month
     kanji: 八日
   - japanese: ここのか*
-    english: day 9
+    english: ninth day of the month
     kanji: 九日
   - japanese: とおか*
-    english: day 10
+    english: tenth day of the month
     kanji: 十日
   - japanese: じゅういちにち
-    english: day 11
+    english: eleventh day of the month
     kanji: 十一日
   - japanese: じゅうににち
-    english: day 12
+    english: twelfth day of the month
     kanji: 十二日
   - japanese: じゅうさんにち
-    english: day 13
+    english: thirteenth day of the month
     kanji: 十三日
   - japanese: じゅうよっか*
-    english: day 14
+    english: fourteenth day of the month
     kanji: 十四日
   - japanese: じゅうごにち
-    english: day 15
+    english: fifteenth day of the month
     kanji: 十五日
   - japanese: 〜にち
     english: day ...
     kanji: 〜日
   - japanese: はつか*
-    english: day 20
+    english: twentieth day of the month
     kanji: 二十日・廿日
   - japanese: にじゅうよっか*
-    english: day 24
+    english: twenty-fourth day of the month
     kanji: 二十四日

--- a/data/genki_1/templates/L04/05_time_words.yaml
+++ b/data/genki_1/templates/L04/05_time_words.yaml
@@ -5,13 +5,13 @@ cards:
   vocabulary:
   - japanese: おととい
     english: the day before yesterday
-    kanjis: ''
+    kanji: ''
   - japanese: きのう
     english: yesterday
-    kanjis: 昨日
+    kanji: 昨日
   - japanese: せんしゅう
     english: last week
-    kanjis: 先週
+    kanji: 先週
   - japanese: きょう
     english: today
     kanji: 今日
@@ -20,49 +20,49 @@ cards:
     kanji: 明日
   - japanese: あさって
     english: the day after tomorrow
-    kanjis: ''
+    kanji: ''
   - japanese: にしゅうかんまえ
     english: two weeks ago
-    kanjis: 二週間前
+    kanji: 二週間前
   - japanese: せんしゅう
     english: last week
     kanji: 先週
   - japanese: こんしゅう
     english: this week
-    kanjis: 今週
+    kanji: 今週
   - japanese: らいしゅう
     english: next week
-    kanjis: 来週
+    kanji: 来週
   - japanese: さらいしゅう
     english: the week after next
-    kanjis: 再来週
+    kanji: 再来週
   - japanese: にかげつまえ
     english: two months ago
-    kanjis: 二か月前
+    kanji: 二か月前
   - japanese: せんげつ
     english: last month
-    kanjis: 先月
+    kanji: 先月
   - japanese: こんげつ
     english: this month
-    kanjis: 今月
+    kanji: 今月
   - japanese: らいげつ
     english: next month
-    kanjis: 来月
+    kanji: 来月
   - japanese: さらいげつ
     english: the month after next
-    kanjis: 再来月
+    kanji: 再来月
   - japanese: おととし
     english: the year before last
-    kanjis: ''
+    kanji: ''
   - japanese: きょねん
     english: last year
-    kanjis: 去年
+    kanji: 去年
   - japanese: ことし
     english: this year
-    kanjis: 今年
+    kanji: 今年
   - japanese: らいねん
     english: next year
-    kanjis: 来年
+    kanji: 来年
   - japanese: さらいねん
     english: the year after next
-    kanjis: 再来年
+    kanji: 再来年

--- a/data/genki_1/templates/L05/01_vocabulary.yaml
+++ b/data/genki_1/templates/L05/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L05/K05_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904400
 sound_silence_threshold: 600
 cards:
@@ -70,7 +70,7 @@ cards:
   - japanese: さむい
     english: cold (weather - not used for things)
     kanji: 寒い
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
   - japanese: いそがしい
     english: busy (people/days)
     kanji: 忙しい
@@ -141,7 +141,7 @@ cards:
   - japanese: きく
     english: to listen; to hear (〜を); to ask (<i>person</i>&nbsp;に)
     kanji: 聞く
-    skip_on_semikolon: 0
+    skip_on_semicolon: 0
   - japanese: のる
     english: to ride; to board (〜に)
     kanji: 乗る

--- a/data/genki_1/templates/L06/01_vocabulary.yaml
+++ b/data/genki_1/templates/L06/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L06/K06_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904500
 sound_silence_threshold: 600
 cards:
@@ -105,7 +105,7 @@ cards:
   - japanese: やすむ
     english: (1) to be absent (from ...) (〜を)<div>(2) to rest</div>
     kanji: 休む
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
 - category: Ru-verbs
   vocabulary:
   - japanese: あける

--- a/data/genki_1/templates/L06/02_useful_expressions.yaml
+++ b/data/genki_1/templates/L06/02_useful_expressions.yaml
@@ -5,37 +5,37 @@ cards:
   vocabulary:
   - japanese: ひだりにまがる
     english: turn left
-    kanjis: 左に曲がる
+    kanji: 左に曲がる
   - japanese: みぎにまがる
     english: turn right
-    kanjis: 右に曲がる
+    kanji: 右に曲がる
   - japanese: まっすぐいく
     english: go straight
-    kanjis: まっすぐ行く
+    kanji: まっすぐ行く
   - japanese: みちをわたる
     english: cross the street
-    kanjis: 道を渡る
+    kanji: 道を渡る
   - japanese: ふたつめのかどをひだりにまがる
     english: turn left at the second corner
-    kanjis: ニつ目の角を左に曲がる
+    kanji: ニつ目の角を左に曲がる
   - japanese: ひとつめのしんごうをみぎにまがる
     english: turn right at the first traffic light
-    kanjis: 一つ目の信号を右に曲がる
+    kanji: 一つ目の信号を右に曲がる
   - japanese: みちのひだりがわ
     english: left side of the street
-    kanjis: 道の左側
+    kanji: 道の左側
   - japanese: みちのみぎがわ
     english: right side of the street
-    kanjis: 道の右側
+    kanji: 道の右側
   - japanese: きた
     english: north
-    kanjis: 北
+    kanji: 北
   - japanese: にし
     english: west
-    kanjis: 西
+    kanji: 西
   - japanese: ひがし
     english: east
-    kanjis: 東
+    kanji: 東
   - japanese: みなみ
     english: south
-    kanjis: 南
+    kanji: 南

--- a/data/genki_1/templates/L07/01_vocabulary.yaml
+++ b/data/genki_1/templates/L07/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L07/K07_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904600
 sound_silence_threshold: 600
 cards:

--- a/data/genki_1/templates/L07/02_counting_people.yaml
+++ b/data/genki_1/templates/L07/02_counting_people.yaml
@@ -4,33 +4,33 @@ cards:
 - category: counting_people
   vocabulary:
   - japanese: ひとり*
-    english: 1 Person/alone
+    english: one person
     kanji: 一人
   - japanese: ふたり*
-    english: 2 Persons/couple
+    english: two people
     kanji: 二人
   - japanese: さんにん
-    english: 3 Persons
+    english: three people
     kanji: 三人
   - japanese: よにん*
-    english: 4 Persons
+    english: four people
     kanji: 四人
   - japanese: ごにん
-    english: 5 Persons
+    english: five people
     kanji: 五人
   - japanese: ろくにん
-    english: 6 Persons
+    english: six people
     kanji: 六人
-  - japanese: しちにん*・ななにん
-    english: 7 Persons
+  - japanese: しちにん／ななにん
+    english: seven people
     kanji: 七人
   - japanese: はちにん
-    english: 8 Persons
+    english: eight people
     kanji: 八人
   - japanese: きゅうにん
-    english: 9 Persons
+    english: nine people
     kanji: 九人
   - japanese: じゅうにん
-    english: 10 Persons
+    english: ten people
     kanji: 十人
 

--- a/data/genki_1/templates/L07/03_bodyparts.yaml
+++ b/data/genki_1/templates/L07/03_bodyparts.yaml
@@ -2,63 +2,63 @@ sound_file:
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904602
 sound_silence_threshold: 600
 cards:
-- category: Useful_Expressions
-  vocabulary:
-  - japanese: かみ
-    english: hair
-    kanjis: 髪
-  - japanese: くち
-    english: mouth
-    kanjis: 口
-  - japanese: め
-    english: eye
-    kanjis: 目
-  - japanese: はな
-    english: nose
-    kanjis: 鼻
-  - japanese: ゆび
-    english: finger
-    kanjis: 指
-  - japanese: は
-    english: tooth
-    kanjis: 歯
-  - japanese: まゆげ
-    english: eyebrows
-    kanjis: 眉毛
-  - japanese: みみ
-    english: ear
-    kanjis: 耳
-  - japanese: て
-    english: hand
-    kanjis: 手
-  - japanese: くび
-    english: neck
-    kanjis: 首
-  - japanese: あたま
-    english: head
-    kanjis: 頭
-  - japanese: せなか
-    english: back
-    kanjis: 背中
-  - japanese: おしり
-    english: buttocks
-    kanjis: ''
-  - japanese: かお
-    english: face
-    kanjis: 顔
-  - japanese: かた
-    english: shoulder
-    kanjis: 肩
-  - japanese: むね
-    english: breast
-    kanjis: 胸
-  - japanese: おなか
-    english: stomach
-    kanjis: ''
-  - japanese: あし
-    english: leg; foot
-    kanjis: 足
+  - category: Useful_Expressions
+    vocabulary:
+      - japanese: かみ
+        english: hair
+        kanji: 髪
+      - japanese: くち
+        english: mouth
+        kanji: 口
+      - japanese: め
+        english: eye
+        kanji: 目
+      - japanese: はな
+        english: nose
+        kanji: 鼻
+      - japanese: ゆび
+        english: finger
+        kanji: 指
+      - japanese: は
+        english: tooth
+        kanji: 歯
+      - japanese: まゆげ
+        english: eyebrows
+        kanji: 眉毛
+      - japanese: みみ
+        english: ear
+        kanji: 耳
+      - japanese: て
+        english: hand
+        kanji: 手
+      - japanese: くび
+        english: neck
+        kanji: 首
+      - japanese: あたま
+        english: head
+        kanji: 頭
+      - japanese: せなか
+        english: back
+        kanji: 背中
+      - japanese: おしり
+        english: buttocks
+        kanji: ""
+      - japanese: かお
+        english: face
+        kanji: 顔
+      - japanese: かた
+        english: shoulder
+        kanji: 肩
+      - japanese: むね
+        english: breast
+        kanji: 胸
+      - japanese: おなか
+        english: stomach
+        kanji: ""
+      - japanese: あし
+        english: leg; foot
+        kanji: 足

--- a/data/genki_1/templates/L08/01_vocabulary.yaml
+++ b/data/genki_1/templates/L08/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L08/K08_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904700
 sound_silence_threshold: 600
 cards:
@@ -177,7 +177,7 @@ cards:
   - japanese: まだ + negative
     english: not ... yet
     kanji: ''
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: 〜について
     english: about ...; concerning ...
     kanji: ''

--- a/data/genki_1/templates/L08/02_foods.yaml
+++ b/data/genki_1/templates/L08/02_foods.yaml
@@ -16,9 +16,9 @@ cards:
   - japanese: おにぎり
     english: Rice balls
   - japanese: ラーメン
-    english: ramen noodels
+    english: ramen noodles
   - japanese: うどん
-    english: udon noodels
+    english: udon noodles
   - japanese: パスタ
     english: pasta
   - japanese: ぎょうざ

--- a/data/genki_1/templates/L09/01_vocabulary.yaml
+++ b/data/genki_1/templates/L09/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L09/K09_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904800
 sound_silence_threshold: 600
 cards:
@@ -124,7 +124,7 @@ cards:
   - japanese: でる
     english: (1) to appear; to attend (〜に)<div>(2) to exit (〜を)</div>
     kanji: 出る
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
 - category: Irregular_Verbs
   vocabulary:
   - japanese: うんどうする

--- a/data/genki_1/templates/L09/02_colors.yaml
+++ b/data/genki_1/templates/L09/02_colors.yaml
@@ -2,7 +2,7 @@ sound_file:
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904801
 sound_silence_threshold: 600
 cards:
@@ -10,58 +10,58 @@ cards:
   vocabulary:
   - japanese: くろい
     english: black
-    kanjis: 黒い
+    kanji: 黒い
   - japanese: しろい
     english: white
-    kanjis: 白い
+    kanji: 白い
   - japanese: あかい
     english: red
-    kanjis: 赤い
+    kanji: 赤い
   - japanese: あおい
     english: blue
-    kanjis: 青い
+    kanji: 青い
   - japanese: きいろい
     english: yellow
-    kanjis: 黄色い
+    kanji: 黄色い
   - japanese: ちゃいろい
     english: brown
-    kanjis: 茶色い
+    kanji: 茶色い
   - japanese: みどり／グリーン
     english: green
-    kanjis: 緑
+    kanji: 緑
   - japanese: こんいろ
     english: navy blue
-    kanjis: 紺色
+    kanji: 紺色
   - japanese: みずいろ
     english: light blue
-    kanjis: 水色
+    kanji: 水色
   - japanese: ぎんいろ／シルバー
     english: silver
-    kanjis: 銀色
+    kanji: 銀色
   - japanese: オレンジ
     english: orange
-    kanjis: ''
+    kanji: ''
   - japanese: むらさき
     english: purple
-    kanjis: 紫
+    kanji: 紫
   - japanese: はいいろ／グレー
     english: gray
-    kanjis: 灰色
+    kanji: 灰色
   - japanese: きんいろ／ゴールド
     english: gold
-    kanjis: 金色
+    kanji: 金色
   - japanese: ピンク
     english: pink
-    kanjis: ''
+    kanji: ''
   - japanese: ベージュ
     english: beige
-    kanjis: ''
+    kanji: ''
   - japanese: かおがあおいですね。
     english: You look pale.
-    kanjis: 顔が青いですね。
+    kanji: 顔が青いですね。
   - japanese: しろくろのしゃしん
     english: black and white picture
-    kanjis: 白黒の写真
+    kanji: 白黒の写真
   - japanese: あおしんごう
     english: green light
-    kanjis: 青信号
+    kanji: 青信号

--- a/data/genki_1/templates/L10/01_vocabulary.yaml
+++ b/data/genki_1/templates/L10/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L10/K10_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904900
 sound_silence_threshold: 600
 cards:
@@ -125,7 +125,7 @@ cards:
   - japanese: かかる
     english: to take (amount of time/money) (<i>no particle</i>)
     kanji: ''
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: とまる
     english: to stay (at a hotel, etc.) (〜に)
     kanji: 泊まる
@@ -156,7 +156,7 @@ cards:
   - japanese: どっち／どちら
     english: which
     kanji: ''
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: はやく
     english: (do something) early; fast
     kanji: 早く／速く
@@ -175,11 +175,11 @@ cards:
   - japanese: 〜しゅうかん
     english: for ... weeks
     kanji: 〜週間
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: 〜かげつ
     english: for ... months
     kanji: 〜か月
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: 〜ねん
     english: '... years'
     kanji: 〜年

--- a/data/genki_1/templates/L10/02_train_station.yaml
+++ b/data/genki_1/templates/L10/02_train_station.yaml
@@ -2,7 +2,7 @@ sound_file:
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693904901
 sound_silence_threshold: 600
 cards:
@@ -10,109 +10,109 @@ cards:
   vocabulary:
   - japanese: ふつう
     english: local (train)
-    kanjis: 普通
+    kanji: 普通
   - japanese: きゅうこう
     english: express (train)
-    kanjis: 急行
+    kanji: 急行
   - japanese: とっきゅう
     english: super express (train)
-    kanjis: 特急
+    kanji: 特急
   - japanese: 〜いき
     english: bound for ...
-    kanjis: 〜行き
+    kanji: 〜行き
   - japanese: 〜ほうめん
     english: serving ... areas
-    kanjis: 〜方面
+    kanji: 〜方面
   - japanese: じょうしゃけん
     english: (boarding) ticket
-    kanjis: 乗車券
+    kanji: 乗車券
   - japanese: ていきけん
     english: commuter's pass
-    kanjis: 定期券
+    kanji: 定期券
   - japanese: がくわり
     english: student discount
-    kanjis: 学割
+    kanji: 学割
   - japanese: していせき
     english: reserved seat
-    kanjis: 指定席
+    kanji: 指定席
   - japanese: こうつうけいアイシーカード
     english: rechargeable card such as Suica, Icoca, Pasmo, etc.
-    kanjis: 交通系ICカード
+    kanji: 交通系ICカード
   - japanese: じゆうせき
     english: general admission seat
-    kanjis: 自由席
+    kanji: 自由席
   - japanese: いちごうしゃ
     english: Car No. 1
-    kanjis: 一号車
+    kanji: 一号車
   - japanese: おうふく
     english: round trip
-    kanjis: 往復
+    kanji: 往復
   - japanese: かたみち
     english: one way
-    kanjis: 片道
+    kanji: 片道
   - japanese: 〜ばんせん
     english: track number ...
-    kanjis: 〜番線
+    kanji: 〜番線
   - japanese: きっぷうりば
     english: ticket vending area
-    kanjis: 切符売り場
+    kanji: 切符売り場
   - japanese: かいさつ
     english: gate
-    kanjis: 改札
+    kanji: 改札
   - japanese: ホーム
     english: platform
-    kanjis: ''
+    kanji: ''
   - japanese: ばいてん
     english: shop; stand
-    kanjis: 売店
+    kanji: 売店
   - japanese: でぐち
     english: exit
-    kanjis: 出口
+    kanji: 出口
   - japanese: いりぐち
     english: entrance
-    kanjis: 入口
+    kanji: 入口
   - japanese: かいだん
     english: stairs
-    kanjis: 階段
+    kanji: 階段
   - japanese: のりかえ
     english: transfer
-    kanjis: 乗り換え
+    kanji: 乗り換え
   - japanese: つぎは〜
     english: next (stop), ...
-    kanjis: 次は〜
+    kanji: 次は〜
   - japanese: せんぱつ
     english: departing first
-    kanjis: 先発
+    kanji: 先発
   - japanese: じはつ
     english: departing second
-    kanjis: 次発
+    kanji: 次発
   - japanese: しゅうでん
     english: last train
-    kanjis: 終電
+    kanji: 終電
   - japanese: まもなくはっしゃします。
     english: We will be leaving soon.
-    kanjis: まもなく発車します。
+    kanji: まもなく発車します。
   - japanese: でんしゃがまいります。
     english: A train is arriving.
-    kanjis: 電車が参ります。
+    kanji: 電車が参ります。
   - japanese: つぎは〜にとまります。
     english: Next (we'll stop at) ...
-    kanjis: 次は〜に止まります。
+    kanji: 次は〜に止まります。
   - japanese: ドアがしまります。ごちゅういください。
     english: The doors are closing. Please be careful.
-    kanjis: ドアが閉まります。ご注意ください。
+    kanji: ドアが閉まります。ご注意ください。
   - japanese: このでんしゃはあきはばらにとまりますか。
     english: Does this train stop at Akihabara?
-    kanjis: この電車は秋葉原に止まりますか。
+    kanji: この電車は秋葉原に止まりますか。
   - japanese: しゅうでんはなんじですか。
     english: What time is the last train?
-    kanjis: 終電は何時ですか。
+    kanji: 終電は何時ですか。
   - japanese: とうきょうまでのしていせきをいちまいおねがいします。
     english: One reserved ticket to Tokyo, please.
-    kanjis: 東京までの指定席を一枚お願いします。
+    kanji: 東京までの指定席を一枚お願いします。
   - japanese: がくわりがつかえますか。
     english: Can I get a student discount?
-    kanjis: 学割が使えますか。
+    kanji: 学割が使えますか。
   - japanese: かまくらいきのでんしゃはどれですか。
     english: Which one is the train bound for Kamakura?
-    kanjis: 鎌倉行きの電車はどれですか。
+    kanji: 鎌倉行きの電車はどれですか。

--- a/data/genki_1/templates/L11/01_vocabulary.yaml
+++ b/data/genki_1/templates/L11/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L11/K11_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905000
 sound_silence_threshold: 600
 cards:

--- a/data/genki_1/templates/L11/02_additional_vocabulary.yaml
+++ b/data/genki_1/templates/L11/02_additional_vocabulary.yaml
@@ -1,7 +1,7 @@
 sound_file: Kaiwa_Bunpo_L11/K11_09.mp3
 skip_with_new_category: false
 skip_on_beginning: 1
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905001
 sound_silence_threshold: 600
 cards:

--- a/data/genki_1/templates/L11/03_japanese_class.yaml
+++ b/data/genki_1/templates/L11/03_japanese_class.yaml
@@ -2,7 +2,7 @@ sound_file:
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905002
 sound_silence_threshold: 600
 cards:
@@ -10,106 +10,106 @@ cards:
   vocabulary:
   - japanese: どちらでもいいです。
     english: Both are fine.
-    kanjis: ''
+    kanji: ''
   - japanese: おなじです。
     english: Same thing.
-    kanjis: 同じです。
+    kanji: 同じです。
   - japanese: だいたいおなじです。
     english: More or less the same.
-    kanjis: だいたい同じです。
+    kanji: だいたい同じです。
   - japanese: ちょっとちがいます。
     english: A little different.
-    kanjis: ちょっと違います。
+    kanji: ちょっと違います。
   - japanese: つかえません。
     english: Can't use it.
-    kanjis: 使えません
+    kanji: 使えません
   - japanese: だめです。
     english: No good.
-    kanjis: ''
+    kanji: ''
   - japanese: てをあげてください。
     english: Raise your hand.
-    kanjis: 手をあげてください。
+    kanji: 手をあげてください。
   - japanese: よんできてください。
     english: Read it before coming to class.
-    kanjis: 読んできてください。
+    kanji: 読んできてください。
   - japanese: しゅくだいをだしてください。
     english: Hand in the homework.
-    kanjis: 宿題を出してください。
+    kanji: 宿題を出してください。
   - japanese: １０ページをひらいてください。
     english: Open the book to page 10.
-    kanjis: １０ページを開いてください。
+    kanji: １０ページを開いてください。
   - japanese: きょうかしょをとじてください。
     english: Close the textbook.
-    kanjis: 教科書を閉じてください。
+    kanji: 教科書を閉じてください。
   - japanese: となりのひとにきいてください。
     english: Ask the person sitting next to you.
-    kanjis: となりの人に聞いてください。
+    kanji: となりの人に聞いてください。
   - japanese: やめてください。
     english: Please stop.
-    kanjis: ''
+    kanji: ''
   - japanese: きょうはこれでおわります。
     english: That's it for today.
-    kanjis: 今日はこれで終わります。
+    kanji: 今日はこれで終わります。
   - japanese: しめきり
     english: deadline
-    kanjis: ''
+    kanji: ''
   - japanese: れんしゅう
     english: exercise
-    kanjis: 練習
+    kanji: 練習
   - japanese: いみ
     english: meaning
-    kanjis: 意味
+    kanji: 意味
   - japanese: はつおん
     english: pronunciation
-    kanjis: 発音
+    kanji: 発音
   - japanese: ぶんぽう
     english: grammar
-    kanjis: 文法
+    kanji: 文法
   - japanese: しつもん
     english: question
-    kanjis: 質問
+    kanji: 質問
   - japanese: こたえ
     english: answer
-    kanjis: 答
+    kanji: 答
   - japanese: れい
     english: example
-    kanjis: 例
+    kanji: 例
   - japanese: かっこ
     english: ( ) (parentheses)
-    kanjis: ''
+    kanji: ''
   - japanese: まる
     english: ○ (correct)
-    kanjis: ''
+    kanji: ''
   - japanese: ばつ
     english: ☓ (wrong)
-    kanjis: ''
+    kanji: ''
   - japanese: くだけたいいかた
     english: colloquial expression
-    kanjis: くだけた言い方
+    kanji: くだけた言い方
   - japanese: かたいいいかた
     english: bookish expression
-    kanjis: かたい言い方
+    kanji: かたい言い方
   - japanese: ていねいないいかた
     english: polite expression
-    kanjis: ていねいな言い方
+    kanji: ていねいな言い方
   - japanese: ほうげん
     english: dialect
-    kanjis: 方言
+    kanji: 方言
   - japanese: きょうつうご
     english: common language
-    kanjis: 共通語
+    kanji: 共通語
   - japanese: たとえば
     english: for example
-    kanjis: ''
+    kanji: ''
   - japanese: ほかに
     english: anything else
-    kanjis: ''
+    kanji: ''
   - japanese: 〜ばん
     english: number ...
     kanji: ''
   - japanese: 〜ぎょうめ
     english: line number ...
-    kanjis: 〜行目
+    kanji: 〜行目
   - japanese: ふたりずつ
     english: two people each
-    kanjis: 二人ずつ
+    kanji: 二人ずつ

--- a/data/genki_1/templates/L12/01_vocabulary.yaml
+++ b/data/genki_1/templates/L12/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L12/K12_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905100
 sound_silence_threshold: 600
 cards:
@@ -91,7 +91,7 @@ cards:
   - japanese: せまい
     english: narrow; not spacious
     kanji: 狭い
-    skip_on_semikolon: false
+    skip_on_semicolon: false
   - japanese: ひろい
     english: wide; spacious
     kanji: 広い
@@ -168,7 +168,7 @@ cards:
   - japanese: もうすぐ
     english: very soon; in a few moments/days
     kanji: ''
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
   - japanese: はじめて
     english: for the first time
     kanji: 初めて

--- a/data/genki_1/templates/L12/02_health_and_illness.yaml
+++ b/data/genki_1/templates/L12/02_health_and_illness.yaml
@@ -2,7 +2,7 @@ sound_file:
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905101
 sound_silence_threshold: 600
 cards:
@@ -10,91 +10,91 @@ cards:
   vocabulary:
   - japanese: げりです。
     english: I have diarrhea.
-    kanjis: 下痢です。
+    kanji: 下痢です。
   - japanese: べんぴです。
     english: I am constipated.
-    kanjis: 便秘です。
+    kanji: 便秘です。
   - japanese: せいりです。
     english: I have my period.
-    kanjis: 生理です。
+    kanji: 生理です。
   - japanese: かふんしょうです。
     english: I have hay fever.
-    kanjis: 花粉症です。
+    kanji: 花粉症です。
   - japanese: （〜に）アレルギーがあります。
     english: I have an allergy to ...
-    kanjis: ''
+    kanji: ''
   - japanese: むしばがあります。
     english: I have a bad tooth.
-    kanjis: 虫歯があります。
+    kanji: 虫歯があります。
   - japanese: くしゃみがでます。
     english: I sneeze.
-    kanjis: くしゃみが出ます。
+    kanji: くしゃみが出ます。
   - japanese: はなみずがでます。
     english: I have a runny nose.
-    kanjis: 鼻水が出ます。
+    kanji: 鼻水が出ます。
   - japanese: せなかがかゆいです。
     english: My back itches.
-    kanjis: 背中がかゆいです。
+    kanji: 背中がかゆいです。
   - japanese: はっしんがあります。
     english: I have rashes.
-    kanjis: 発疹があります。
+    kanji: 発疹があります。
   - japanese: めまいがします。
     english: I feel dizzy.
-    kanjis: ''
+    kanji: ''
   - japanese: はきました。
     english: I threw up.
-    kanjis: 吐きました。
+    kanji: 吐きました。
   - japanese: きぶんがわるいです。
     english: I am not feeling well.
-    kanjis: 気分が悪いです。
+    kanji: 気分が悪いです。
   - japanese: やけどをしました。
     english: I burned myself.
-    kanjis: ''
+    kanji: ''
   - japanese: あしをこっせつしました。
     english: I broke my leg.
-    kanjis: 足を骨折しました。
+    kanji: 足を骨折しました。
   - japanese: けがをしました。
     english: I hurt myself.
-    kanjis: ''
+    kanji: ''
   - japanese: ないか
     english: physician
-    kanjis: 内科
+    kanji: 内科
   - japanese: ひふか
     english: dermatologist
-    kanjis: 皮膚科
+    kanji: 皮膚科
   - japanese: げか
     english: surgeon
-    kanjis: 外科
+    kanji: 外科
   - japanese: さんふじんか
     english: obsterician and gynecologist
-    kanjis: 産婦人科
+    kanji: 産婦人科
   - japanese: せいけいげか
     english: orthopedic surgeon
-    kanjis: 整形外科
+    kanji: 整形外科
   - japanese: がんか（めいしゃ）
     english: ophthalmologist
-    kanjis: 眼科（目医者）
+    kanji: 眼科（目医者）
   - japanese: しか（はいしゃ）
     english: dentist
-    kanjis: 歯科（歯医者）
+    kanji: 歯科（歯医者）
   - japanese: じびか
     english: otorhinolaryngologist; ENT doctor
-    kanjis: 耳鼻科
+    kanji: 耳鼻科
   - japanese: こうせいぶっしつ
     english: antibiotic
-    kanjis: 抗生物質
+    kanji: 抗生物質
   - japanese: レントゲン
     english: X-ray
-    kanjis: ''
+    kanji: ''
   - japanese: しゅじゅつ
     english: operation
-    kanjis: 手術
+    kanji: 手術
   - japanese: ちゅうしゃ
     english: injection
-    kanjis: 注射
+    kanji: 注射
   - japanese: たいおんけい
     english: thermometer
-    kanjis: 体温計
+    kanji: 体温計
   - japanese: てんてき
     english: intravenous feeding
-    kanjis: 点滴
+    kanji: 点滴

--- a/data/genki_2/templates/L13/01_vocabulary.yaml
+++ b/data/genki_2/templates/L13/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L13/K13_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905200
 sound_silence_threshold: 600
 cards:
@@ -83,7 +83,7 @@ cards:
   - japanese: やくそく
     english: promise; appointment
     kanji: 約束
-    skip_on_semikolon: false
+    skip_on_semicolon: false
 - category: い-adjectives
   vocabulary:
   - japanese: うれしい

--- a/data/genki_2/templates/L13/01_vocabulary.yaml
+++ b/data/genki_2/templates/L13/01_vocabulary.yaml
@@ -43,7 +43,7 @@ cards:
     kanji: ''
   - japanese: ぞう
     english: elephant
-    kanji: 像
+    kanji: 象
   - japanese: からだ
     english: body
     kanji: 体

--- a/data/genki_2/templates/L14/01_vocabulary.yaml
+++ b/data/genki_2/templates/L14/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L14/K14_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905300
 sound_silence_threshold: 600
 cards:

--- a/data/genki_2/templates/L15/01_vocabulary.yaml
+++ b/data/genki_2/templates/L15/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L15/K15_07.mp3
 #skip_words: [87]
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905400
 sound_silence_threshold: 600
 cards:
@@ -126,7 +126,7 @@ cards:
   - japanese: きをつける
     english: to be cautious/careful(〜に)
     kanji: 気をつける
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: しらべる
     english: to look into (matterを)
     kanji: 調べる
@@ -177,4 +177,4 @@ cards:
   - japanese: たのしみです
     english: cannot wait; look forward to it
     kanji: 楽しみです
-    #skip_on_semikolon: 1
+    #skip_on_semicolon: 1

--- a/data/genki_2/templates/L16/01_vocabulary.yaml
+++ b/data/genki_2/templates/L16/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L16/K16_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905500
 sound_silence_threshold: 600
 cards:
@@ -32,7 +32,7 @@ cards:
   - japanese: みち
     english: way; road; directions
     kanji: 道
-    skip_on_semikolon: False
+    skip_on_semicolon: False
   - japanese: きまつしけん
     english: final examination
     kanji: 期末試験

--- a/data/genki_2/templates/L17/01_vocabulary.yaml
+++ b/data/genki_2/templates/L17/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L17/K17_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905600
 sound_silence_threshold: 600
 cards:
@@ -97,7 +97,7 @@ cards:
   - japanese: すくない
     english: a little; a few
     kanji: 少ない
-    skip_on_semikolon: False
+    skip_on_semicolon: False
   - japanese: つごうがわるい
     english: inconvenient; to have a scheduling conflict
     kanji: 都合が悪い

--- a/data/genki_2/templates/L18/01_vocabulary.yaml
+++ b/data/genki_2/templates/L18/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L18/K18_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905700
 sound_silence_threshold: 600
 cards:
@@ -78,7 +78,7 @@ cards:
     kanji: 暗い
   - japanese: はずかしい
     english: embarrasing
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
     kanji: 恥ずかしい
 - category: な-adjectives
   vocabulary:
@@ -177,7 +177,7 @@ cards:
   - japanese: どうしよう
     english: What should I/we do?
     kanji: ''
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: ～（ん）だろう
     english: short form of ～（ん）でしょう
     kanji: ''

--- a/data/genki_2/templates/L19/01_vocabulary.yaml
+++ b/data/genki_2/templates/L19/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L19/K19_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905800
 sound_silence_threshold: 600
 cards:
@@ -61,7 +61,7 @@ cards:
   - japanese: なかがいい
     english: be on good/close terms; to get along well
     kanji: 仲がいい
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
 - category: な-adjectives
   vocabulary:
   - japanese: まじめ(な)
@@ -72,11 +72,11 @@ cards:
   - japanese: いらっしゃる
     english: honorific expression for いく、くる、and いる
     kanji: ''
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
   - japanese: めしあがる
     english: honorific expression for たべる、のむ
     kanji: 召し上がる
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: くださる
     english: honorific expression for くれる
     kanji: 下さる
@@ -98,7 +98,7 @@ cards:
   - japanese: おくる
     english: to walk/drive (someone) (personをplaceまで)
     kanji: 送る
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: おこる
     english: to get angry
     kanji: 怒る
@@ -136,7 +136,7 @@ cards:
   - japanese: ごちそうする
     english: to treat/invite (someone) to a meal (person に meal を)
     kanji: ご馳走する（rare）
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: えんりょする
     english: to hold back for the time being; to refrain from
     kanji: 遠慮する
@@ -157,7 +157,7 @@ cards:
   - japanese: それで
     english: then; therefore
     kanji: 其れで（rare）
-    skip_on_semikolon: False
+    skip_on_semicolon: False
   - japanese: なぜ
     english: why (=どうして)
     kanji: 何故（rare）
@@ -173,7 +173,7 @@ cards:
   - japanese: ～めいさま
     english: a party of ... People
     kanji: ～名様
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: ようこそ
     english: welcome
     kanji: ''

--- a/data/genki_2/templates/L20/01_vocabulary.yaml
+++ b/data/genki_2/templates/L20/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L20/K20_05.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693905900
 sound_silence_threshold: 600
 cards:
@@ -17,7 +17,7 @@ cards:
   - japanese: しゅみ
     english: hobby; pastime
     kanji: 趣味
-    skip_on_semikolon: False
+    skip_on_semicolon: False
   - japanese: つき
     english: moon
     kanji: 月
@@ -48,7 +48,7 @@ cards:
   - japanese: おたく
     english: (someone's) home/house
     kanji: お宅
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: ～や
     english: …shop
     kanji: ～屋
@@ -121,7 +121,7 @@ cards:
   - japanese: もどる
     english: to return; to come back (～に)
     kanji: 戻る
-    skip_on_semikolon: False
+    skip_on_semicolon: False
 - category: Ru-verbs
   vocabulary:
   - japanese: さしあげる

--- a/data/genki_2/templates/L21/01_vocabulary.yaml
+++ b/data/genki_2/templates/L21/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L21/K21_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693906000
 sound_silence_threshold: 600
 cards:
@@ -81,7 +81,7 @@ cards:
   - japanese: めちゃくちゃ(な)
     english: messy; disorganized
     kanji: 目茶苦茶（rare）
-    skip_on_semikolon: False
+    skip_on_semicolon: False
   - japanese: へん(な)
     english: strange; unusual
     kanji: 変

--- a/data/genki_2/templates/L22/01_vocabulary.yaml
+++ b/data/genki_2/templates/L22/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L22/K22_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693906100
 sound_silence_threshold: 600
 cards:
@@ -113,7 +113,7 @@ cards:
   - japanese: ほ（う）っておく
     english: to leave (someone/something) alone; to neglect (～を)
     kanji: 放っておく
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
   - japanese: まにあう
     english: to be in time  (～に)
     kanji: 間に合う

--- a/data/genki_2/templates/L23/01_vocabulary.yaml
+++ b/data/genki_2/templates/L23/01_vocabulary.yaml
@@ -2,7 +2,7 @@ sound_file: Kaiwa_Bunpo_L23/K23_07.mp3
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: 693906200
 sound_silence_threshold: 600
 cards:
@@ -14,7 +14,7 @@ cards:
   - japanese: ふくろ
     english: sack; plastic/paper bag
     kanji: 袋
-    skip_on_semikolon: 2
+    skip_on_semicolon: 2
   - japanese: ただ
     english: free of charge
     kanji: 只（rare）
@@ -117,7 +117,7 @@ cards:
   - japanese: がまんする
     english: to be tolerant/patient (～を)
     kanji: 我慢する
-    skip_on_semikolon: 1
+    skip_on_semicolon: 1
   - japanese: どうじょうする
     english: to sympathize (～に)
     kanji: 同情する

--- a/download_fonts.py
+++ b/download_fonts.py
@@ -1,5 +1,7 @@
-from google_drive_downloader import GoogleDriveDownloader as gdd
+import gdown
+import os
+
+os.makedirs('./data/fonts', exist_ok=True)
 
 # https://drive.google.com/file/d/1BW6v1gTps7NTl8Zvg9D4C5pjbyrpCu63/view?usp=sharing
-gdd.download_file_from_google_drive(file_id='1BW6v1gTps7NTl8Zvg9D4C5pjbyrpCu63',
-                                    dest_path='./data/fonts/_NotoSansCJKjp-Regular.woff2')
+gdown.download(id='1BW6v1gTps7NTl8Zvg9D4C5pjbyrpCu63', output='./data/fonts/_NotoSansCJKjp-Regular.woff2')

--- a/download_genki_sound_files.py
+++ b/download_genki_sound_files.py
@@ -1,11 +1,26 @@
-from google_drive_downloader import GoogleDriveDownloader as gdd
+import gdown
+import os
+import zipfile
 
+# Create directories if they don't exist
+os.makedirs('./data/genki_1/sound', exist_ok=True)
+os.makedirs('./data/genki_2/sound', exist_ok=True)
+
+# Function to unzip the downloaded files
+def unzip_file(zip_path, extract_to):
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(extract_to)
+    print(f"Unzipped {zip_path} to {extract_to}")
+
+# Download the Genki sound files
 # https://drive.google.com/file/d/1RXnr3nEiv5gFGIQqdMugrETwXu-lsar1/view?usp=share_link
-gdd.download_file_from_google_drive(file_id='1RXnr3nEiv5gFGIQqdMugrETwXu-lsar1',
-                                    dest_path='./data/genki_1/sound/genki_1_sounds.zip',
-                                    unzip=True)
+gdown.download(id='1RXnr3nEiv5gFGIQqdMugrETwXu-lsar1', output='./data/genki_1/sound/genki_1_sounds.zip')
+
+# Unzip the first file
+unzip_file('./data/genki_1/sound/genki_1_sounds.zip', './data/genki_1/sound')
 
 # https://drive.google.com/file/d/1KPkNM85bM4zymzqO-aLWELah-RVM2p3O/view?usp=share_link
-gdd.download_file_from_google_drive(file_id='1KPkNM85bM4zymzqO-aLWELah-RVM2p3O',
-                                    dest_path='./data/genki_2/sound/genki_2_sounds.zip',
-                                    unzip=True)
+gdown.download(id='1KPkNM85bM4zymzqO-aLWELah-RVM2p3O', output='./data/genki_2/sound/genki_2_sounds.zip')
+
+# Unzip the second file
+unzip_file('./data/genki_2/sound/genki_2_sounds.zip', './data/genki_2/sound')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ genanki
 #git+https://github.com/mi-ael/genanki#egg=genanki
 cachier
 num2words
-googledrivedownloader
+gdown

--- a/src/data.py
+++ b/src/data.py
@@ -41,7 +41,7 @@ class Deck:
         self.uid: int = None
         self.skip_with_new_category: bool = False
         self.skip_on_beginning: int = 0
-        self.skip_on_semikolon: bool = True
+        self.skip_on_semicolon: bool = True
         self.sound_silence_threshold: int = None
         self.only_japanese: bool = False
 
@@ -95,10 +95,10 @@ class Deck:
             if subtag is not None:
                 card.tags.append(subtag)
             deck.cards.append(card)
-            if "skip_on_semikolon" not in e and deck.skip_on_semikolon or "skip_on_semikolon" in e and (e["skip_on_semikolon"] == True or (type(e["skip_on_semikolon"]) == int and e["skip_on_semikolon"] != 0)):
+            if "skip_on_semicolon" not in e and deck.skip_on_semicolon or "skip_on_semicolon" in e and (e["skip_on_semicolon"] == True or (type(e["skip_on_semicolon"]) == int and e["skip_on_semicolon"] != 0)):
                 skips = card.english.replace("&nbsp;", "").count(';')
-                if "skip_on_semikolon" in e and type(e["skip_on_semikolon"]) == int:
-                    skips = e["skip_on_semikolon"]
+                if "skip_on_semicolon" in e and type(e["skip_on_semicolon"]) == int:
+                    skips = e["skip_on_semicolon"]
                 for _ in range(skips):
                     deck.skip_words.append(skip_index)
                     skip_index = skip_index+1
@@ -119,7 +119,7 @@ class Deck:
         deck.skip_words.extend(range(deck.skip_on_beginning))
         skip_index = deck.skip_on_beginning
         deck.skip_with_new_category = doc.get("skip_with_new_category", True)
-        deck.skip_on_semikolon = doc.get("skip_on_semikolon", True)
+        deck.skip_on_semicolon = doc.get("skip_on_semicolon", True)
         deck.sound_silence_threshold = doc.get("sound_silence_threshold", 600)
         deck.only_japanese = doc.get("only_japanese", False)
         for c in doc["cards"]:

--- a/utils/csv2yaml.py
+++ b/utils/csv2yaml.py
@@ -11,7 +11,7 @@ yaml_head = """sound_file: {sound_file}
 skip_words: []
 skip_on_beginning: 2
 skip_with_new_category: true
-skip_on_semikolon: true
+skip_on_semicolon: true
 uid: {uid}
 sound_silence_threshold: 600
 cards:"""

--- a/utils/gen_anki_data.py
+++ b/utils/gen_anki_data.py
@@ -33,7 +33,7 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 2 and tag == 'U-verbs':
         for v in cat['vocabulary']:
             if v['japanese'] == 'きく':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
     if i == 3 and stag == 'People_and_Things':
         desk = cat['vocabulary'].pop(0)
         chair = cat['vocabulary'].pop(0)
@@ -42,10 +42,10 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 4 and tag == 'い-adjectives':
         for v in cat['vocabulary']:
             if v['japanese'] == 'さむい':
-                v['skip_on_semikolon'] = 2
+                v['skip_on_semicolon'] = 2
     if i == 4 and tag == 'U-verbs':
         ask = cat['vocabulary'].pop(0)
-        ask['skip_on_semikolon'] = 0
+        ask['skip_on_semicolon'] = 0
         cat['vocabulary'].insert(1, ask)
     if i == 5 and tag == 'Nouns':
         electricity = cat['vocabulary'].pop(0)
@@ -61,7 +61,7 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 5 and tag == 'U-verbs':
         for v in cat['vocabulary']:
             if v['japanese'] == 'やすむ':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
     if i == 6 and tag == 'Nouns':
         os = cat['vocabulary'].pop(0)
         ob = cat['vocabulary'].pop(0)
@@ -83,7 +83,7 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 7 and tag == 'Adverbs_and_Other_Expressions':
         for v in cat['vocabulary']:
             if v['english'] == 'not ... yet':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
     if i == 8 and tag == 'Nouns':
         lm = cat['vocabulary'].pop(0)
         ly = cat['vocabulary'].pop(0)
@@ -92,7 +92,7 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 8 and tag == 'Ru-verbs':
         for v in cat['vocabulary']:
             if v['japanese'] == 'でる':
-                v['skip_on_semikolon'] = 2
+                v['skip_on_semicolon'] = 2
     if i == 9 and tag == 'Nouns':
         d = cat['vocabulary'].pop(0)
         ty = cat['vocabulary'].pop(0)
@@ -105,15 +105,15 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 9 and tag == 'U-verbs':
         for v in cat['vocabulary']:
             if v['japanese'] == 'かかる':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
     if i == 9 and tag == 'Adverbs_and_Other_Expressions':
         for v in cat['vocabulary']:
             if v['japanese'] == 'どっち／どちら':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
             if v['japanese'] == '〜しゅうかん':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
             if v['japanese'] == '〜かげつ':
-                v['skip_on_semikolon'] = 1
+                v['skip_on_semicolon'] = 1
     if i == 10 and tag == 'Nouns':
         aus = cat['vocabulary'].pop(0)
         cat['vocabulary'].insert(1, aus)
@@ -127,11 +127,11 @@ def apply_hacks(cat, i, tag, stag=None):
     if i == 11 and tag == 'い-adjectives':
         for v in cat['vocabulary']:
             if v['japanese'] == 'せまい':
-                v['skip_on_semikolon'] = False
+                v['skip_on_semicolon'] = False
     if i == 11 and tag == 'Adverbs_and_Other_Expressions':
         for v in cat['vocabulary']:
             if v['japanese'] == 'もうすぐ':
-                v['skip_on_semikolon'] = 2
+                v['skip_on_semicolon'] = 2
 
     for v in cat['vocabulary']:
         if 'kanji' in v:
@@ -193,7 +193,7 @@ def get_out_dict(mayor, sound_file=None, minor=0):
         'skip_words': [],
         'skip_on_beginning': 2,
         'skip_with_new_category': True,
-        'skip_on_semikolon': True,
+        'skip_on_semicolon': True,
         'uid': 693904000 + mayor*100 + minor,
         'sound_silence_threshold': 600,
         'cards': [],
@@ -270,11 +270,11 @@ for i,deck in enumerate(vocab):
 
     out_dict = get_out_dict(i, vocab_sound_files[i])
     if i==0:
-        out_dict['skip_on_semikolon'] = False
+        out_dict['skip_on_semicolon'] = False
         out_dict['sound_silence_threshold'] = 1000
     # if i==2:
     #     out_dict['skip_on_beginning'] = 1
-    #     out_dict['skip_on_semikolon'] = False
+    #     out_dict['skip_on_semicolon'] = False
     if i==3:
         out_dict['sound_silence_threshold'] = 300
 
@@ -325,7 +325,7 @@ for t in tags:
         cat['vocabulary'] = [{'japanese': v['jap'], 'english': v['eng'], 'kanji': v['kan']} for v in vocs]
         for v in cat['vocabulary']:
             if v['japanese'] == 'いいえ。':
-                v['skip_on_semikolon'] = False
+                v['skip_on_semicolon'] = False
     else:
         scats = []
         for stag in subtags:


### PR DESCRIPTION
I've included a handful of updates in this PR, mainly:

- updated the elephant kanji as mentioned in #24 
- fixed the various issues mentioned in #25 
- fixed spelling of "semikolon" to "semicolon"
- switched to `gdown` for google drive file downloads. Not sure if this is necessary, but I was unable to get `google-drive-downloader` working on MacOS. `gdown` is also a much more popular package so maybe it will be better maintained

These decks are great and I hope we can work to keep them updated. Thanks!